### PR TITLE
reworked service worker to improve caching for some file types

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    
+    <link rel="preload" href="/style/css/style.css" as="style">
+    <!-- <link rel="preload" href="/style/font/OpenSans-Regular.ttf" as="font" crossorigin> -->
 
     <script>
-        if (navigator.serviceWorker) {
-            console.log("register service worker");
+        if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("/service-worker.js", {
                 scope : "/"
             });

--- a/service-worker.js
+++ b/service-worker.js
@@ -4,37 +4,48 @@
  * -> for github it is easier to move the service worker into the
  *    required scope folder
  */
-var cacheName = "static-cache";
+var cachePatterns = [
+    new RegExp(/(\.ttf|\.png|\.jpe?g|\.gif|\.ico)$/)
+];
+var cacheDuration = 60 * 60 * 24 * 365;
 
 self.addEventListener("install", function(e){
-    e.waitUntil(buildCache());
+    if ("skipWaiting" in self) {
+        self.skipWaiting();
+    }
+});
+
+self.addEventListener("activate", function(e){
+    if (typeof clients !== "undefined" && "claim" in clients) {
+        e.waitUntil(clients.claim());
+    }
 });
 
 self.addEventListener("fetch", function(e){
-    e.respondWith(fromCache(e.request));
+    if (matchesCachePattern(e.request.url)) {
+        e.respondWith(modifiedResponse(e.request));
+    }else{
+        e.respondWith(fetch(e.request));
+    }
 });
 
-function buildCache() {
-    return caches.open(cacheName).then(function(cache) {
-        return cache.addAll([
-            "/style/font/OpenSans-Regular.ttf",
-            "/style/font/RobotoMono-Regular.ttf"
-        ]);
-    });
-}
-
-function fromCache(request) {
-    return caches.open(cacheName).then(function(cache) {
-        return cache.match(request).then(function(match) {
-            return match || fetch(request);
-        })
-    });
-}
-
-function update(request) {
-    return caches.open(cacheName).then(function(cache) {
-        return fetch(request).then(function(response) {
-            return cache.put(request, response);
+function modifiedResponse(request) {
+    return fetch(request).then((response) => {
+        let headers = new Headers(response.headers);
+        headers.set("cache-control", "public, max-age=" + cacheDuration);
+        return new Response(response.body, {
+            status : response.status,
+            statusText : response.statusText,
+            headers : headers
         });
     });
+}
+
+function matchesCachePattern(url) {
+    for (const pattern of cachePatterns) {
+        if (pattern.test(url)) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/style/css/style.css
+++ b/style/css/style.css
@@ -431,7 +431,7 @@ body[data-light-mode] .sun-moon::after {
 .layout-container .content ol.codeblock {
     box-sizing: border-box;
     margin: 0.5em 0;
-    padding: 0.5em 1em 0.5em 0.5em;
+    padding: 0.5em;
     background-color: var(--content-box-bg-color);    
     font-family: "Roboto Mono Regular", monospace;
     list-style: none;


### PR DESCRIPTION
GitHub pages serves all responses with a `cache-control` header that tells the browser that the file will be stale after 10 minutes.
The service worker will now intercept the response for certain file types that are considered static, like images and fonts, and modify the `cache-control` header of the response to increase the cache max age of the file fo 1 year.